### PR TITLE
Removed sleeping message during day

### DIFF
--- a/Harbor/src/techtoolbox/Harbor/ActionBarMessage.java
+++ b/Harbor/src/techtoolbox/Harbor/ActionBarMessage.java
@@ -9,7 +9,7 @@ public class ActionBarMessage implements Runnable {
 			if (((Main.worlds.get(Bukkit.getServer().getWorlds().get(i))).intValue() > 0) && ((Main.worlds.get(Bukkit.getServer().getWorlds().get(i))).intValue() < (Bukkit.getServer().getWorlds().get(i)).getPlayers().size() - Main.bypassers.size())) {
 				Main.sendActionbar("playersInBed", Bukkit.getServer().getWorlds().get(i));
 			}
-			else if (((Main.worlds.get(Bukkit.getServer().getWorlds().get(i))).intValue() == (Bukkit.getServer().getWorlds().get(i)).getPlayers().size() - Main.bypassers.size()) && ((Bukkit.getServer().getWorlds().get(i)).getPlayers().size() > 1)) {
+			else if (((Main.worlds.get(Bukkit.getServer().getWorlds().get(i))).intValue() == (Bukkit.getServer().getWorlds().get(i)).getPlayers().size() - Main.bypassers.size()) && ((Bukkit.getServer().getWorlds().get(i)).getPlayers().size() - Main.bypassers.size() > 1)) {
 				Main.sendActionbar("everyoneSleeping", Bukkit.getServer().getWorlds().get(i));
 			}
 		}


### PR DESCRIPTION
Fixed problem with actionbar showing "everyone is sleeping"-message during day.
https://github.com/nkomarn/Harbor/issues/4

This might summon it better:
`(amount_of_player_sleeping == (total_players - player_with_special_permission)) AND (total_players > 1)` => `(0 == 2-2) AND (2 > 1)`